### PR TITLE
fix broken urls

### DIFF
--- a/intro-wikipedia/assets/setup.sh
+++ b/intro-wikipedia/assets/setup.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 pkgs=(
     p/postgresql-common/postgresql-client-common_190ubuntu0.1_all.deb
-    p/postgresql-10/libpq5_10.12-0ubuntu0.18.04.1_amd64.deb
-    p/postgresql-10/postgresql-client-10_10.12-0ubuntu0.18.04.1_amd64.deb
+    p/postgresql-10/libpq5_10.14-0ubuntu0.18.04.1_amd64.deb
+    p/postgresql-10/postgresql-client-10_10.14-0ubuntu0.18.04.1_amd64.deb
 )
 
 echo "Installing PostgreSQL..."


### PR DESCRIPTION
The Katacoda demo currently breaks with a 404 error -- this will temporarily fix it, but i think this will break again when the packages get updated.  maybe we should try and grab the directory contents (ie, http://security.ubuntu.com/ubuntu/pool/main/p/postgresql-10/) and look for the latest deb package matching the prefix?