### PR TITLE
fix urls broken by mtrlz.dev dns change

### DIFF
--- a/intro-wikipedia/assets/setup.sh
+++ b/intro-wikipedia/assets/setup.sh
@@ -20,7 +20,7 @@ done
 echo "Installing Materialize..."
 version=$(curl -fsSL https://materialize.io/docs/versions.json | jq -r .[0].name)
 echo "Latest stable release: $version"
-curl -fsSL https://downloads.mtrlz.dev/materialized-"$version"-x86_64-unknown-linux-gnu.tar.gz \
+curl -fsSL https://binaries.materialize.com/materialized-"$version"-x86_64-unknown-linux-gnu.tar.gz \
     | tar -xzC /usr/local --strip-components=1
 
 echo "Installation complete! You can now go ahead and run Materialize:"

--- a/intro-wikipedia/step1.md
+++ b/intro-wikipedia/step1.md
@@ -12,7 +12,7 @@ To help you get started with Materialize, we'll:
 
 (These steps are being run for you automatically)
 
-`curl -L https://downloads.mtrlz.dev/materialized-v0.3.1-x86_64-unknown-linux-gnu.tar.gz \
+`curl -L https://binaries.materialize.com/materialized-latest-x86_64-unknown-linux-gnu.tar.gz \
     | tar -xzC /usr/local --strip-components=1`{{execute}}
 
 Install psql

--- a/intro-wikipedia/step1.md
+++ b/intro-wikipedia/step1.md
@@ -12,7 +12,7 @@ To help you get started with Materialize, we'll:
 
 (These steps are being run for you automatically)
 
-`curl -L https://binaries.materialize.com/materialized-latest-x86_64-unknown-linux-gnu.tar.gz \
+`curl -L https://binaries.materialize.com/materialized-v0.8.0-x86_64-unknown-linux-gnu.tar.gz \
     | tar -xzC /usr/local --strip-components=1`{{execute}}
 
 Install psql


### PR DESCRIPTION
note that step1.md changes from a hardcoded "v0.3.1" to "materialized-latest"